### PR TITLE
Persist printed document metadata snapshots

### DIFF
--- a/Outlaw_LawTablet/README.md
+++ b/Outlaw_LawTablet/README.md
@@ -50,14 +50,17 @@ Avocat Tablet + Bloc-note + Impression en item (doc_*).
 - Créer une note (Plainte/Procès/Note), puis **Imprimer** avec l'ID → reçoit un item `doc_*` avec un snapshot HTML.
 - **Utiliser** l'item `doc_*` → ouvre le lecteur (read-only) du document imprimé.
 - Dans la tablette: champ "Code document" → bouton **Vérifier** pour valider un code public.
+- Chaque item imprimé conserve sa metadata complète (`metadata.document`, `note_snapshot`, etc.) pour garder le contenu même si la note d'origine change ou est supprimée.
 
 ## SQL
-Tables créées automatiquement au démarrage (voir `server/migrations.lua`):
+Tables créées automatiquement au démarrage (voir `server/migrations.lua`). Le script attend l'évènement `MySQL.ready` (oxmysql) ou `onMySQLReady` (mysql-async), donc aucune action manuelle n'est nécessaire sur les installations standards :
 - `outlaw_notes`
 - `outlaw_documents_printed`
+> Si les tables n'apparaissent pas, vérifiez que la ressource `oxmysql` est bien démarrée avant `Outlaw_LawTablet` et relancez la ressource pour rejouer les migrations.
 
 ## Sécurité & Permissions
-- `Config.WriterJob = 'avocat'` contrôle qui peut créer/imprimer.
+- `Config.WriterJob = 'avocat'` contrôle qui peut créer/imprimer (accepte un string ou une liste `{ 'avocat', 'lawyer' }`).
+- Les membres du métier défini dans `Config.WriterJob` ainsi que l'auteur du document peuvent toujours lire leurs impressions.
 - `Config.AllowPoliceRead = true` permet la lecture côté police (optionnel).
 - Le contenu est **sanitizé** côté serveur de manière simple (MVP).
 

--- a/Outlaw_LawTablet/client/main.lua
+++ b/Outlaw_LawTablet/client/main.lua
@@ -27,6 +27,16 @@ RegisterNUICallback('list_notes', function(data, cb)
   cb(res or { ok=false })
 end)
 
+RegisterNUICallback('get_note', function(data, cb)
+  local id = data and data.id
+  if type(id) ~= 'number' then
+    cb({ ok=false, error='invalid_id' })
+    return
+  end
+  local res = lib.callback.await('outlaw_lawtablet:notes:get', false, id)
+  cb(res or { ok=false })
+end)
+
 RegisterNUICallback('print_document', function(data, cb)
   local res = lib.callback.await('outlaw_lawtablet:documents:print', false, { note_id = data.note_id })
   cb(res or { ok=false })
@@ -35,6 +45,18 @@ end)
 RegisterNUICallback('verify_code', function(data, cb)
   local res = lib.callback.await('outlaw_lawtablet:documents:verify', false, data and data.code or '')
   cb(res or { ok=false })
+end)
+
+RegisterNUICallback('close_document', function(data, cb)
+  local showApp = data and data.showApp
+  if showApp then
+    SetNuiFocus(true, true)
+    uiOpen = true
+  else
+    SetNuiFocus(false, false)
+    uiOpen = false
+  end
+  cb(true)
 end)
 
 RegisterNetEvent('outlaw_lawtablet:client:openDocument', function(meta)

--- a/Outlaw_LawTablet/config.lua
+++ b/Outlaw_LawTablet/config.lua
@@ -1,7 +1,7 @@
 Config = Config or {}
 
--- Which job can create/edit (others can read if they have access to item and permissions)?
-Config.WriterJob = 'avocat'   -- change to your job name
+-- Which job(s) can create/edit (others can read if they have the item)? Can be a string or an array.
+Config.WriterJob = 'avocat'   -- change to your job name or { 'avocat', 'lawyer' }
 Config.AllowPoliceRead = true -- police can read documents if true
 
 -- Item names (must be defined in ox_inventory items data file)

--- a/Outlaw_LawTablet/html/app.css
+++ b/Outlaw_LawTablet/html/app.css
@@ -18,9 +18,13 @@ body { margin:0; font-family: Inter, Arial, sans-serif; background: transparent;
 
 .list { display:flex; flex-direction:column; gap:6px; max-height: 52vh; overflow:auto }
 .row { display:flex; justify-content:space-between; align-items:center; gap:8px; padding:8px; background: rgba(255,255,255,.03); border:1px solid rgba(255,255,255,.05); border-radius:10px }
+.row.clickable { cursor:pointer; transition: background .15s ease, border-color .15s ease; }
+.row.clickable:hover { background: rgba(122,162,255,.12); border-color: rgba(122,162,255,.35); }
 .row .id { opacity:.7; font-size:12px }
 .row .title { font-weight:600 }
 .row .type { font-size:12px; opacity:.8 }
+
+.empty { padding:18px 12px; text-align:center; opacity:.7; font-size:13px; border:1px dashed rgba(255,255,255,.1); border-radius:10px }
 
 .form { display:flex; flex-direction:column; gap:8px }
 .form input, .form select, .form textarea { width:100%; padding:8px 10px; border-radius:10px; background: rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.1); color:#eaefff }
@@ -29,6 +33,11 @@ button { cursor:pointer; padding:8px 12px; border-radius: 10px; border:1px solid
 
 .hint { font-size:12px; opacity:.8; margin-top:6px }
 
-.doc-layer { position: fixed; inset: 0; background: rgba(0,0,0,.65); display:flex; flex-direction:column; padding: 24px; gap:10px }
-.doc-header { display:flex; justify-content:space-between; align-items:center }
-#doc-frame { flex:1; width:100%; border-radius: 12px; border:1px solid rgba(255,255,255,.12); background: #0b0f1a }
+.doc-layer { position: fixed; inset: 0; background: rgba(4,6,12,.75); display:flex; align-items:center; justify-content:center; padding: 32px; z-index:999 }
+.doc-modal { width: min(960px, 94vw); max-height: 90vh; display:flex; flex-direction:column; gap:0; background: rgba(12,16,28,.95); border:1px solid rgba(255,255,255,.12); border-radius: 16px; box-shadow: 0 24px 60px rgba(0,0,0,.6); overflow:hidden }
+.doc-header { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; padding: 18px 22px; border-bottom:1px solid rgba(255,255,255,.08) }
+.doc-titles { display:flex; flex-direction:column; gap:4px; min-width:0 }
+.doc-title { font-weight:600; font-size:18px; color:#f3f5ff; word-break:break-word }
+.doc-subtitle { font-size:12px; opacity:.75; color:#d0d6f9; word-break:break-word }
+.doc-subtitle.hidden { display:none }
+#doc-frame { flex:1; width:100%; border:0; border-radius: 0 0 16px 16px; background: #0b0f1a; min-height: 60vh }

--- a/Outlaw_LawTablet/html/app.js
+++ b/Outlaw_LawTablet/html/app.js
@@ -1,11 +1,22 @@
 const app = document.getElementById('app');
 const docLayer = document.getElementById('doc');
 const docFrame = document.getElementById('doc-frame');
+const docTitleEl = document.getElementById('doc-title');
+const docSubtitleEl = document.getElementById('doc-subtitle');
+let lastDocUrl = null;
+let appWasVisibleBeforeDoc = false;
 
 const tabs = document.querySelectorAll('.tab');
 const listTitle = document.getElementById('list-title');
 const filterType = document.getElementById('filter-type');
 const listEl = document.getElementById('list');
+
+const TYPE_LABELS = {
+  complaint: 'Plainte',
+  trial: 'Procès',
+  note: 'Note',
+  other: 'Autre'
+};
 
 const btnClose = document.getElementById('btn-close');
 const btnRefresh = document.getElementById('btn-refresh');
@@ -22,6 +33,43 @@ const fPrintId = document.getElementById('f-print-id');
 const verifyInput = document.getElementById('verify-input');
 const printResult = document.getElementById('print-result');
 
+function escapeHtml(str) {
+  return String(str == null ? '' : str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function cleanText(value) {
+  if (value == null) return '';
+  const text = String(value).trim();
+  return text;
+}
+
+function docSubtitle(meta) {
+  if (!meta || typeof meta !== 'object') return '';
+  const parts = [];
+  const typeKey = meta.type || (meta.source && meta.source.type) || '';
+  const type = cleanText(meta.type_label || (typeKey && TYPE_LABELS[typeKey]) || typeKey);
+  if (type) parts.push(type);
+  const noteId = cleanText(
+    (meta.note_id != null ? `#${meta.note_id}` : '') ||
+    (meta.source && meta.source.note_id != null ? `#${meta.source.note_id}` : '')
+  );
+  if (noteId) parts.push(noteId);
+  const status = cleanText(meta.status);
+  if (status) parts.push(status);
+  const printedAt = cleanText(meta.printed_at || meta.created_at || meta.updated_at);
+  if (printedAt) parts.push(printedAt);
+  const author = cleanText(meta.author || meta.author_charname || (meta.printed_by && (meta.printed_by.charname || meta.printed_by.name)));
+  if (author) parts.push(author);
+  const tags = cleanText(meta.tags);
+  if (tags) parts.push(tags);
+  return parts.join(' • ');
+}
+
 function postNui(action, data) {
   return new Promise((resolve) => {
     fetch(`https://${GetParentResourceName()}/${action}`, {
@@ -36,18 +84,33 @@ function switchTab(t) {
   tabs.forEach(btn => btn.classList.toggle('active', btn.dataset.tab === t));
   listTitle.textContent = t === 'complaint' ? 'Plainte' : t === 'trial' ? 'Procès' : 'Notes';
   filterType.value = t;
+  if ([...fType.options].some(opt => opt.value === t)) {
+    fType.value = t;
+  }
   refreshList();
 }
 
 function rowEl(item) {
   const div = document.createElement('div');
-  div.className = 'row';
+  div.className = 'row clickable';
+  const rawTitle = typeof item.title === 'string' && item.title.trim() !== '' ? item.title : 'Sans titre';
+  const rawType = TYPE_LABELS[item.type] || item.type || 'Note';
+  const rawStatus = item.status || '';
+  const idText = item.id != null ? String(item.id) : '?';
   div.innerHTML = `
     <div>
-      <div class="title">\${item.title}</div>
-      <div class="type">\${item.type} • \${item.status}</div>
+      <div class="title">${escapeHtml(rawTitle)}</div>
+      <div class="type">${escapeHtml(rawType)} • ${escapeHtml(rawStatus)}</div>
     </div>
-    <div class="id">#\${item.id}</div>`;
+    <div class="id">#${escapeHtml(idText)}</div>`;
+  div.addEventListener('click', () => openNote(Number(item.id)));
+  div.tabIndex = 0;
+  div.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter' || ev.key === ' ') {
+      ev.preventDefault();
+      openNote(Number(item.id));
+    }
+  });
   return div;
 }
 
@@ -55,6 +118,13 @@ async function refreshList() {
   const r = await postNui('list_notes', { type: filterType.value });
   listEl.innerHTML = '';
   if (!r.ok) { listEl.textContent = 'Erreur de chargement'; return; }
+  if (!Array.isArray(r.items) || r.items.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.textContent = 'Aucun document';
+    listEl.appendChild(empty);
+    return;
+  }
   r.items.forEach(it => listEl.appendChild(rowEl(it)));
 }
 
@@ -95,33 +165,129 @@ async function verifyCode() {
   alert('Document VALIDE (hash: ' + r.hash + ')');
 }
 
+async function openNote(id) {
+  if (!id || Number.isNaN(id)) return;
+  const r = await postNui('get_note', { id });
+  if (!r.ok || !r.item) {
+    alert('Impossible d\'ouvrir la note (introuvable)');
+    return;
+  }
+  const note = r.item;
+  const typeLabel = TYPE_LABELS[note.type] || note.type || 'Note';
+  const title = escapeHtml(note.title && note.title.trim() !== '' ? note.title : 'Sans titre');
+  const status = escapeHtml(note.status || '');
+  const tags = escapeHtml(note.tags || '');
+  const author = escapeHtml(note.author_charname || 'Inconnu');
+  const createdAt = escapeHtml(note.created_at || '');
+  const body = escapeHtml(note.body || '');
+  const html = `
+    <style>
+      body { font-family: Arial, sans-serif; background:#0b0f1a; color:#eaefff; margin:0; padding:24px; }
+      .doc { max-width:860px; margin:0 auto; background:rgba(20,24,36,.92); border-radius:16px; border:1px solid rgba(255,255,255,.12); padding:24px 28px; }
+      .meta { font-size:13px; opacity:.8; margin-bottom:12px; display:flex; flex-direction:column; gap:4px; }
+      .meta span { display:block; }
+      h1 { margin:0 0 12px 0; font-size:24px; }
+      .body { line-height:1.6; white-space:pre-wrap; background:rgba(255,255,255,.04); padding:16px; border-radius:12px; }
+      .tags { margin-top:12px; font-size:12px; opacity:.75; }
+    </style>
+    <div class="doc">
+      <h1>${title}</h1>
+      <div class="meta">
+        <span>Type: ${escapeHtml(typeLabel)}</span>
+        <span>Statut: ${status}</span>
+        <span>Auteur: ${author}</span>
+        <span>Créé le: ${createdAt}</span>
+      </div>
+      <div class="body">${body.trim() !== '' ? body : '<em>Sans contenu</em>'}</div>
+      ${tags ? `<div class="tags">Tags: ${tags}</div>` : ''}
+    </div>`;
+  let modalTitle = cleanText(note.title);
+  if (!modalTitle) {
+    modalTitle = note.id != null ? `${typeLabel} #${note.id}` : typeLabel;
+  }
+
+  openDocument({
+    body_html: html,
+    title: modalTitle,
+    type: note.type,
+    type_label: typeLabel,
+    status: note.status,
+    created_at: note.created_at,
+    author: note.author_charname,
+    tags: note.tags
+  });
+}
+
 // NUI open/close
 window.addEventListener('message', (e) => {
   const d = e.data || {};
   if (d.action === 'open') {
+    closeDocument(false);
     app.classList.remove('hidden');
     switchTab('complaint');
   } else if (d.action === 'openDocument') {
-    app.classList.add('hidden');
     openDocument(d.meta);
   }
 });
 
 function openDocument(meta) {
+  appWasVisibleBeforeDoc = !app.classList.contains('hidden');
+  app.classList.add('hidden');
   docLayer.classList.remove('hidden');
+  const titleText = cleanText(meta && meta.title) || 'Document';
+  docTitleEl.textContent = titleText;
+  const subtitleText = docSubtitle(meta);
+  if (subtitleText) {
+    docSubtitleEl.textContent = subtitleText;
+    docSubtitleEl.classList.remove('hidden');
+  } else {
+    docSubtitleEl.textContent = '';
+    docSubtitleEl.classList.add('hidden');
+  }
   // Build sandboxed HTML for viewing the stored snapshot
   const html = meta && meta.body_html ? meta.body_html : '<p>Document vide</p>';
   const blob = new Blob([html], { type: 'text/html' });
-  const url = URL.createObjectURL(blob);
-  docFrame.src = url;
+  if (lastDocUrl) {
+    URL.revokeObjectURL(lastDocUrl);
+  }
+  lastDocUrl = URL.createObjectURL(blob);
+  docFrame.src = lastDocUrl;
 }
 
-document.getElementById('doc-close').addEventListener('click', () => {
+function closeDocument(showApp = true) {
+  if (lastDocUrl) {
+    URL.revokeObjectURL(lastDocUrl);
+    lastDocUrl = null;
+  }
+  docFrame.src = 'about:blank';
   docLayer.classList.add('hidden');
-  app.classList.remove('hidden');
-});
+  docTitleEl.textContent = 'Document';
+  docSubtitleEl.textContent = '';
+  docSubtitleEl.classList.add('hidden');
+  if (showApp) {
+    if (appWasVisibleBeforeDoc) {
+      app.classList.remove('hidden');
+    } else {
+      app.classList.add('hidden');
+    }
+  }
+  appWasVisibleBeforeDoc = false;
+}
 
-btnClose.addEventListener('click', () => postNui('close', {}).then(()=>{}));
+function handleDocClose() {
+  const shouldShowApp = appWasVisibleBeforeDoc;
+  closeDocument(true);
+  postNui('close_document', { showApp: shouldShowApp });
+}
+
+document.getElementById('doc-close').addEventListener('click', handleDocClose);
+
+btnClose.addEventListener('click', () => {
+  postNui('close', {}).finally(() => {
+    closeDocument(false);
+    app.classList.add('hidden');
+  });
+});
 btnRefresh.addEventListener('click', refreshList);
 btnCreate.addEventListener('click', createNote);
 btnPrint.addEventListener('click', printDoc);
@@ -129,3 +295,15 @@ btnVerify.addEventListener('click', verifyCode);
 
 tabs.forEach(btn => btn.addEventListener('click', () => switchTab(btn.dataset.tab)));
 filterType.addEventListener('change', refreshList);
+
+window.addEventListener('keydown', (ev) => {
+  if (ev.key === 'Escape') {
+    if (!docLayer.classList.contains('hidden')) {
+      ev.preventDefault();
+      handleDocClose();
+    } else if (!app.classList.contains('hidden')) {
+      ev.preventDefault();
+      btnClose.click();
+    }
+  }
+});

--- a/Outlaw_LawTablet/html/index.html
+++ b/Outlaw_LawTablet/html/index.html
@@ -83,11 +83,16 @@
 
   <!-- Document Reader -->
   <div id="doc" class="doc-layer hidden">
-    <div class="doc-header">
-      <div>Document imprimé</div>
-      <button id="doc-close">Fermer</button>
+    <div class="doc-modal">
+      <div class="doc-header">
+        <div class="doc-titles">
+          <div id="doc-title" class="doc-title">Document</div>
+          <div id="doc-subtitle" class="doc-subtitle hidden"></div>
+        </div>
+        <button id="doc-close">Fermer</button>
+      </div>
+      <iframe id="doc-frame" title="Document"></iframe>
     </div>
-    <iframe id="doc-frame"></iframe>
   </div>
 
   <script src="app.js"></script>

--- a/Outlaw_LawTablet/server/documents.lua
+++ b/Outlaw_LawTablet/server/documents.lua
@@ -1,3 +1,14 @@
+Documents = Documents or {}
+
+local function deepCopy(value)
+  if type(value) ~= 'table' then return value end
+  local result = {}
+  for k, v in pairs(value) do
+    result[k] = deepCopy(v)
+  end
+  return result
+end
+
 local function randomCode(n)
   local s = ''
   for i=1,n do
@@ -14,6 +25,22 @@ local function simpleHash(str)
     h = ((h * 33) ~ string.byte(str, i)) & 0x7fffffff
   end
   return tostring(h)
+end
+
+local function mergeMissing(dest, src)
+  if type(dest) ~= 'table' or type(src) ~= 'table' then return end
+  for k, v in pairs(src) do
+    local existing = dest[k]
+    if existing == nil then
+      if type(v) == 'table' then
+        dest[k] = deepCopy(v)
+      else
+        dest[k] = v
+      end
+    elseif type(existing) == 'table' and type(v) == 'table' then
+      mergeMissing(existing, v)
+    end
+  end
 end
 
 local function buildHtml(note)
@@ -43,6 +70,238 @@ local function buildHtml(note)
   return html
 end
 
+local function ensureSource(meta)
+  if type(meta.source) ~= 'table' then
+    meta.source = {}
+  end
+  return meta.source
+end
+
+local function unwrapDocumentMeta(meta)
+  local prepared = deepCopy(type(meta) == 'table' and meta or {})
+
+  if type(prepared.document) == 'table' then
+    local doc = prepared.document
+
+    if type(doc.source) == 'table' then
+      local src = ensureSource(prepared)
+      mergeMissing(src, doc.source)
+    end
+
+    if type(doc.note_snapshot) == 'table' and type(prepared.note_snapshot) ~= 'table' then
+      prepared.note_snapshot = deepCopy(doc.note_snapshot)
+    end
+
+    for k, v in pairs(doc) do
+      if k ~= 'source' and k ~= 'note_snapshot' and prepared[k] == nil then
+        if type(v) == 'table' then
+          prepared[k] = deepCopy(v)
+        else
+          prepared[k] = v
+        end
+      end
+    end
+  end
+
+  return prepared
+end
+
+local function applyPrintedRow(meta, row)
+  if not row then return end
+
+  if row.meta_json then
+    local decoded = Utils.jsonDecode(row.meta_json)
+    if type(decoded) == 'table' then
+      local unwrapped = unwrapDocumentMeta(decoded)
+      mergeMissing(meta, unwrapped)
+      if type(unwrapped.source) == 'table' then
+        local src = ensureSource(meta)
+        mergeMissing(src, unwrapped.source)
+      end
+      if type(unwrapped.note_snapshot) == 'table' and type(meta.note_snapshot) ~= 'table' then
+        meta.note_snapshot = deepCopy(unwrapped.note_snapshot)
+      end
+    end
+  end
+
+  meta.doc_id = row.id or meta.doc_id
+  meta.note_id = meta.note_id or row.note_id
+  meta.type = meta.type or row.type
+  if not meta.type_label and meta.type then
+    local typeCfg = Config.Types[meta.type]
+    if typeCfg and typeCfg.label then
+      meta.type_label = typeCfg.label
+    end
+  end
+  meta.title = (meta.title and meta.title ~= '') and meta.title or row.title
+  meta.status = meta.status or row.status
+  meta.tags = meta.tags or row.tags
+  meta.printed_at = meta.printed_at or Utils.toIso8601(row.printed_at)
+  meta.body_html = meta.body_html or row.body_html
+  meta.author = meta.author or row.printed_by_charname
+  meta.author_identifier = meta.author_identifier or row.printed_by_identifier
+
+  if type(meta.printed_by) ~= 'table' then
+    meta.printed_by = {
+      charname = row.printed_by_charname,
+      identifier = row.printed_by_identifier
+    }
+  else
+    meta.printed_by.charname = meta.printed_by.charname or row.printed_by_charname
+    meta.printed_by.identifier = meta.printed_by.identifier or row.printed_by_identifier
+  end
+
+  if type(meta.document) ~= 'table' then
+    meta.document = {}
+  end
+
+  local docMeta = meta.document
+  docMeta.doc_id = docMeta.doc_id or row.id
+  docMeta.note_id = docMeta.note_id or row.note_id
+  docMeta.type = docMeta.type or row.type
+  docMeta.title = docMeta.title or row.title
+  docMeta.status = docMeta.status or row.status
+  docMeta.tags = docMeta.tags or row.tags
+  docMeta.body_html = docMeta.body_html or row.body_html
+  docMeta.printed_at = docMeta.printed_at or Utils.toIso8601(row.printed_at)
+  docMeta.printed_by = docMeta.printed_by or deepCopy(meta.printed_by)
+  docMeta.author = docMeta.author or meta.author
+  docMeta.author_identifier = docMeta.author_identifier or meta.author_identifier
+
+  if type(meta.note_snapshot) == 'table' and docMeta.note_snapshot == nil then
+    docMeta.note_snapshot = deepCopy(meta.note_snapshot)
+  end
+
+  local src = ensureSource(meta)
+  if type(docMeta.source) ~= 'table' then
+    docMeta.source = {}
+  end
+  mergeMissing(docMeta.source, src)
+  src.doc_id = src.doc_id or row.id
+  src.note_id = src.note_id or row.note_id
+  src.type = src.type or row.type
+  src.case_id = src.case_id or row.case_id
+  src.version_id = src.version_id or row.version_id
+  mergeMissing(docMeta.source, src)
+end
+
+local function applyNoteData(meta, note)
+  if type(note) ~= 'table' then return end
+
+  meta.note_snapshot = meta.note_snapshot or deepCopy(note)
+  if type(meta.document) == 'table' and meta.document.note_snapshot == nil then
+    meta.document.note_snapshot = deepCopy(meta.note_snapshot)
+  end
+
+  meta.note_id = meta.note_id or note.id
+  meta.type = meta.type or note.type
+  if not meta.type_label and meta.type then
+    local typeCfg = Config.Types[meta.type]
+    if typeCfg and typeCfg.label then
+      meta.type_label = typeCfg.label
+    end
+  end
+  meta.title = (meta.title and meta.title ~= '') and meta.title or note.title
+  meta.status = meta.status or note.status
+  meta.tags = meta.tags or note.tags
+  meta.created_at = meta.created_at or Utils.toIso8601(note.created_at)
+  meta.author = meta.author or note.author_charname or note.author
+  meta.author_identifier = meta.author_identifier or note.author_identifier
+
+  if not meta.body_html or meta.body_html == '' then
+    if note.body_html and note.body_html ~= '' then
+      meta.body_html = note.body_html
+    elseif note.body and note.body ~= '' then
+      meta.body_html = buildHtml({
+        id = note.id,
+        type = note.type,
+        title = note.title,
+        body = note.body,
+        status = note.status,
+        tags = note.tags,
+        author_charname = note.author_charname
+      })
+    end
+  end
+
+  local src = ensureSource(meta)
+  src.note_id = src.note_id or note.id
+  src.type = src.type or note.type
+  src.case_id = src.case_id or note.case_id
+  src.version_id = src.version_id or note.version_id
+end
+
+local function applyNoteRow(meta, note)
+  if not note then return end
+
+  applyNoteData(meta, note)
+end
+
+function Documents.prepareViewerMeta(meta)
+  local prepared = unwrapDocumentMeta(meta)
+
+  if type(prepared.note_snapshot) == 'table' then
+    applyNoteData(prepared, prepared.note_snapshot)
+  end
+
+  local docId = prepared.doc_id or (prepared.document and prepared.document.doc_id) or (prepared.source and prepared.source.doc_id)
+  if docId ~= nil then
+    docId = tonumber(docId)
+  end
+
+  local noteId = prepared.note_id or (prepared.document and prepared.document.note_id) or (prepared.source and prepared.source.note_id)
+  if noteId ~= nil then
+    noteId = tonumber(noteId)
+  end
+
+  local printedRow
+  if docId then
+    printedRow = MySQL.single.await('SELECT id,note_id,type,title,body_html,status,tags,case_id,version_id,printed_by_identifier,printed_by_charname,printed_at,meta_json FROM outlaw_documents_printed WHERE id = ?', { docId })
+    if printedRow then
+      applyPrintedRow(prepared, printedRow)
+      if type(prepared.note_snapshot) == 'table' then
+        applyNoteData(prepared, prepared.note_snapshot)
+      end
+      noteId = noteId or printedRow.note_id
+    end
+  end
+
+  if noteId then
+    local noteRow = MySQL.single.await('SELECT id,type,title,body,status,tags,author_charname,author_identifier,created_at,case_id,version_id FROM outlaw_notes WHERE id = ? AND deleted_at IS NULL', { noteId })
+    if noteRow then
+      applyNoteRow(prepared, noteRow)
+    end
+  end
+
+  if not prepared.body_html or prepared.body_html == '' then
+    return nil, 'body_missing'
+  end
+
+  if prepared.type and not prepared.type_label then
+    local typeCfg = Config.Types[prepared.type]
+    if typeCfg and typeCfg.label then
+      prepared.type_label = typeCfg.label
+    end
+  end
+
+  return prepared
+end
+
+function Documents.openDocumentForPlayer(source, meta)
+  local prepared, err = Documents.prepareViewerMeta(meta)
+  if not prepared then
+    TriggerClientEvent('ox_lib:notify', source, {
+      type = 'error',
+      title = 'Document',
+      description = err == 'body_missing' and 'Document introuvable ou vide.' or 'Impossible de charger ce document.'
+    })
+    return false
+  end
+
+  TriggerClientEvent('outlaw_lawtablet:client:openDocument', source, prepared)
+  return true
+end
+
 lib.callback.register('outlaw_lawtablet:documents:print', function(source, params)
   if not Perms.canWrite(source) then return { ok=false, error='no_permission' } end
   local id = params and params.note_id
@@ -56,28 +315,90 @@ lib.callback.register('outlaw_lawtablet:documents:print', function(source, param
   local hash = simpleHash(bodyForHash)
   local code = string.format('%s-%s', randomCode(4), randomCode(4))
 
-  local docId = MySQL.insert.await('INSERT INTO outlaw_documents_printed (type,note_id,case_id,version_id,title,body_html,status,tags,printed_by_identifier,printed_by_charname,printed_at,hash,public_code,revoked,meta_json) VALUES (?,?,?,?,?,?,?,?,?,?,NOW(),?,?,0,?)', {
-    note.type, note.id, note.case_id, note.version_id or 1, note.title, html, note.status, note.tags or '',
-    Utils.getIdentifier(source) or 'unknown', Utils.getCharName(source), hash, code, Utils.jsonEncode({ watermark = 'CONFIDENTIEL' })
-  })
-
+  local identifier = Utils.getIdentifier(source) or 'unknown'
+  local charName = Utils.getCharName(source)
+  local printedAtIso = Utils.nowUtcIso()
   local typeCfg = Config.Types[note.type] or Config.Types['note']
-  local itemName = typeCfg.item or Config.Items.DocNote
+  local typeLabel = (typeCfg and typeCfg.label) or note.type or 'Document'
 
-  if exports.ox_inventory then
-    exports.ox_inventory:AddItem(source, itemName, 1, {
-      doc_id = docId,
-      source = { type = note.type, note_id = note.id, case_id = note.case_id, version_id = note.version_id or 1 },
-      title = (typeCfg.label .. ' – ' .. (note.title or ('Note #'..tostring(note.id)))),
-      body_html = html,
+  local docMeta = {
+    note_id = note.id,
+    type = note.type,
+    type_label = typeLabel,
+    title = note.title,
+    status = note.status,
+    tags = note.tags,
+    body_html = html,
+    printed_at = printedAtIso,
+    author = note.author_charname,
+    author_identifier = note.author_identifier,
+    printed_by = { charname = charName, identifier = identifier },
+    signature = { signed = true, signed_by = charName, seal = 'TRIBUNAL-LS', hash = hash, revoked = false },
+    verify = { original_hash = hash, public_code = code, expires_at = nil },
+    source = { type = note.type, note_id = note.id, case_id = note.case_id, version_id = note.version_id or 1 },
+    ui = { watermark = 'CONFIDENTIEL', theme = 'Outlaw' },
+    note_snapshot = {
+      id = note.id,
+      type = note.type,
+      title = note.title,
       status = note.status,
       tags = note.tags,
-      printed_at = os.date('!%Y-%m-%dT%H:%M:%SZ'),
-      printed_by = { charname = Utils.getCharName(source), identifier = Utils.getIdentifier(source) },
-      signature = { signed = true, signed_by = Utils.getCharName(source), seal = 'TRIBUNAL-LS', hash = hash, revoked = false },
-      verify = { original_hash = hash, public_code = code, expires_at = nil },
-      ui = { watermark = 'CONFIDENTIEL', theme = 'Outlaw' }
-    })
+      body = note.body,
+      author_charname = note.author_charname,
+      author_identifier = note.author_identifier,
+      created_at = Utils.toIso8601(note.created_at),
+      case_id = note.case_id,
+      version_id = note.version_id or 1
+    }
+  }
+
+  local initialMetaJson = Utils.jsonEncode(docMeta)
+
+  local docId = MySQL.insert.await('INSERT INTO outlaw_documents_printed (type,note_id,case_id,version_id,title,body_html,status,tags,printed_by_identifier,printed_by_charname,printed_at,hash,public_code,revoked,meta_json) VALUES (?,?,?,?,?,?,?,?,?,?,NOW(),?,?,0,?)', {
+    note.type, note.id, note.case_id, note.version_id or 1, note.title, html, note.status, note.tags or '',
+    identifier, charName, hash, code, initialMetaJson
+  })
+
+  if not docId then
+    return { ok=false, error='insert_failed' }
+  end
+
+  docMeta.doc_id = docId
+  if type(docMeta.source) == 'table' then
+    docMeta.source.doc_id = docId
+  end
+
+  local finalMetaJson = Utils.jsonEncode(docMeta)
+  if finalMetaJson ~= initialMetaJson then
+    MySQL.update.await('UPDATE outlaw_documents_printed SET meta_json = ? WHERE id = ?', { finalMetaJson, docId })
+  end
+
+  local itemName = (typeCfg and typeCfg.item) or Config.Items.DocNote
+
+  if exports.ox_inventory then
+    local metadata = {
+      id = docId,
+      doc_id = docId,
+      note_id = note.id,
+      type = note.type,
+      type_label = docMeta.type_label,
+      title = (typeLabel .. ' – ' .. (note.title and note.title ~= '' and note.title or ('Note #' .. tostring(note.id)))),
+      status = note.status,
+      tags = note.tags,
+      body_html = html,
+      printed_at = printedAtIso,
+      author = note.author_charname,
+      author_identifier = note.author_identifier,
+      printed_by = deepCopy(docMeta.printed_by),
+      signature = deepCopy(docMeta.signature),
+      verify = deepCopy(docMeta.verify),
+      ui = deepCopy(docMeta.ui),
+      source = deepCopy(docMeta.source),
+      note_snapshot = deepCopy(docMeta.note_snapshot),
+      document = deepCopy(docMeta)
+    }
+
+    exports.ox_inventory:AddItem(source, itemName, 1, metadata)
     return { ok=true, id=docId, code=code, hash=hash, item=itemName }
   else
     return { ok=false, error='ox_inventory_missing_but_doc_saved' }

--- a/Outlaw_LawTablet/server/main.lua
+++ b/Outlaw_LawTablet/server/main.lua
@@ -14,9 +14,25 @@ exports('useTablet', function(source, item)
 end)
 
 exports('useDocument', function(source, item)
-  local meta = item and (item.metadata or item.info or {})
-  TriggerClientEvent('outlaw_lawtablet:client:openDocument', source, meta or {})
-  return true
+  local meta
+  if type(item) == 'table' then
+    if type(item.metadata) == 'table' then
+      meta = item.metadata
+    elseif type(item.info) == 'table' then
+      meta = item.info
+    end
+  end
+
+  if not Perms.canReadDocument(source, meta or {}) then
+    TriggerClientEvent('ox_lib:notify', source, {
+      type = 'error',
+      title = 'Accès refusé',
+      description = 'Vous ne pouvez pas lire ce document.'
+    })
+    return false
+  end
+
+  return Documents.openDocumentForPlayer(source, meta or {})
 end)
 
 -- Fallback for servers not wiring item exports:
@@ -26,7 +42,22 @@ AddEventHandler('ox_inventory:usedItem', function(source, itemName, data)
     return
   end
   if itemName == Config.Items.DocPlainte or itemName == Config.Items.DocPlaidoyer or itemName == Config.Items.DocNote then
-    local meta = data and (data.metadata or data.info)
-    TriggerClientEvent('outlaw_lawtablet:client:openDocument', source, meta or {})
+    local meta
+    if type(data) == 'table' then
+      if type(data.metadata) == 'table' then
+        meta = data.metadata
+      elseif type(data.info) == 'table' then
+        meta = data.info
+      end
+    end
+    if not Perms.canReadDocument(source, meta or {}) then
+      TriggerClientEvent('ox_lib:notify', source, {
+        type = 'error',
+        title = 'Accès refusé',
+        description = 'Vous ne pouvez pas lire ce document.'
+      })
+      return
+    end
+    Documents.openDocumentForPlayer(source, meta or {})
   end
 end)

--- a/Outlaw_LawTablet/server/migrations.lua
+++ b/Outlaw_LawTablet/server/migrations.lua
@@ -1,55 +1,74 @@
 local ready = false
+local running = false
 
-AddEventHandler('onMySQLReady', function()
-  -- Create notes table
-  MySQL.query([[
-    CREATE TABLE IF NOT EXISTS outlaw_notes (
-      id INT AUTO_INCREMENT PRIMARY KEY,
-      type VARCHAR(16) NOT NULL,
-      title VARCHAR(128) NOT NULL,
-      body MEDIUMTEXT NOT NULL,
-      status VARCHAR(24) NOT NULL,
-      visibility VARCHAR(64) NOT NULL DEFAULT 'private',
-      tags VARCHAR(255) NULL,
-      case_id INT NULL,
-      linked_ids TEXT NULL,
-      author_identifier VARCHAR(64) NOT NULL,
-      author_charname VARCHAR(96) NOT NULL,
-      concerned_identifier VARCHAR(64) NULL,
-      concerned_charname VARCHAR(96) NULL,
-      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      updated_at TIMESTAMP NULL DEFAULT NULL,
-      deleted_at TIMESTAMP NULL DEFAULT NULL,
-      locked_at TIMESTAMP NULL DEFAULT NULL,
-      locked_by_identifier VARCHAR(64) NULL
-    );
-  ]])
+local function ensureMigrations()
+  if ready or running then return end
+  running = true
 
-  -- Printed documents table
-  MySQL.query([[
-    CREATE TABLE IF NOT EXISTS outlaw_documents_printed (
-      id INT AUTO_INCREMENT PRIMARY KEY,
-      type VARCHAR(16) NOT NULL,
-      note_id INT NULL,
-      case_id INT NULL,
-      version_id INT NULL,
-      title VARCHAR(128) NOT NULL,
-      body_html MEDIUMTEXT NOT NULL,
-      status VARCHAR(24) NULL,
-      tags VARCHAR(255) NULL,
-      printed_by_identifier VARCHAR(64) NOT NULL,
-      printed_by_charname VARCHAR(96) NOT NULL,
-      printed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      hash VARCHAR(128) NOT NULL,
-      public_code VARCHAR(16) NOT NULL,
-      revoked TINYINT(1) NOT NULL DEFAULT 0,
-      meta_json TEXT NULL
-    );
-  ]])
+  local ok, err = pcall(function()
+    -- Create notes table
+    MySQL.query.await([[
+      CREATE TABLE IF NOT EXISTS outlaw_notes (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        type VARCHAR(16) NOT NULL,
+        title VARCHAR(128) NOT NULL,
+        body MEDIUMTEXT NOT NULL,
+        status VARCHAR(24) NOT NULL,
+        visibility VARCHAR(64) NOT NULL DEFAULT 'private',
+        tags VARCHAR(255) NULL,
+        case_id INT NULL,
+        linked_ids TEXT NULL,
+        author_identifier VARCHAR(64) NOT NULL,
+        author_charname VARCHAR(96) NOT NULL,
+        concerned_identifier VARCHAR(64) NULL,
+        concerned_charname VARCHAR(96) NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP NULL DEFAULT NULL,
+        deleted_at TIMESTAMP NULL DEFAULT NULL,
+        locked_at TIMESTAMP NULL DEFAULT NULL,
+        locked_by_identifier VARCHAR(64) NULL
+      );
+    ]])
+
+    -- Printed documents table
+    MySQL.query.await([[
+      CREATE TABLE IF NOT EXISTS outlaw_documents_printed (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        type VARCHAR(16) NOT NULL,
+        note_id INT NULL,
+        case_id INT NULL,
+        version_id INT NULL,
+        title VARCHAR(128) NOT NULL,
+        body_html MEDIUMTEXT NOT NULL,
+        status VARCHAR(24) NULL,
+        tags VARCHAR(255) NULL,
+        printed_by_identifier VARCHAR(64) NOT NULL,
+        printed_by_charname VARCHAR(96) NOT NULL,
+        printed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        hash VARCHAR(128) NOT NULL,
+        public_code VARCHAR(16) NOT NULL,
+        revoked TINYINT(1) NOT NULL DEFAULT 0,
+        meta_json TEXT NULL
+      );
+    ]])
+  end)
+
+  if not ok then
+    running = false
+    print(('[Outlaw_LawTablet] Failed to run DB migrations: %s'):format(err))
+    return
+  end
 
   ready = true
+  running = false
   print('[Outlaw_LawTablet] DB migrations ensured')
-end)
+end
+
+if MySQL and type(MySQL.ready) == 'function' then
+  MySQL.ready(ensureMigrations)
+else
+  AddEventHandler('onMySQLReady', ensureMigrations)
+end
 
 exports('dbReady', function()
   return ready

--- a/Outlaw_LawTablet/server/permissions.lua
+++ b/Outlaw_LawTablet/server/permissions.lua
@@ -2,22 +2,146 @@ Perms = Perms or {}
 
 -- Basic check: authoring allowed if job == Config.WriterJob
 -- You can extend with grade checks or ACE/Custom
+local function normalizeJobName(value)
+  if not value or value == '' then return nil end
+  local vt = type(value)
+  if vt ~= 'string' and vt ~= 'number' then return nil end
+  local str = tostring(value)
+  str = str:gsub('^%s+', ''):gsub('%s+$', '')
+  if str == '' then return nil end
+  return string.lower(str)
+end
+
+local function normalizeIdentifier(value)
+  if value == nil then return nil end
+  local vt = type(value)
+  if vt ~= 'string' and vt ~= 'number' then return nil end
+  local str = tostring(value)
+  if str == '' then return nil end
+  return string.lower(str)
+end
+
+local function identifierMatches(a, b)
+  local na = normalizeIdentifier(a)
+  local nb = normalizeIdentifier(b)
+  return na ~= nil and na == nb
+end
+
+local function extractJobName(job)
+  local jt = type(job)
+  if jt == 'string' or jt == 'number' then
+    return job
+  elseif jt == 'table' then
+    return job.name or job.id or job.job or job.label or job[1]
+  end
+  return nil
+end
+
+local function jobMatches(jobName)
+  local normalized = normalizeJobName(jobName)
+  if not normalized then return false end
+
+  local writerJob = Config.WriterJob
+  if type(writerJob) == 'table' then
+    for _, allowed in ipairs(writerJob) do
+      if normalizeJobName(allowed) == normalized then
+        return true
+      end
+    end
+    return false
+  end
+
+  return normalized == normalizeJobName(writerJob)
+end
+
+local function resolveJobName(xPlayer)
+  if not xPlayer then return nil end
+
+  if type(xPlayer.getJob) == 'function' then
+    local ok, data = pcall(xPlayer.getJob, xPlayer)
+    if ok then
+      local name = extractJobName(data)
+      if name then return name end
+    end
+  end
+
+  local name = extractJobName(xPlayer.job)
+  if name then return name end
+
+  if type(xPlayer.PlayerData) == 'table' then
+    name = extractJobName(xPlayer.PlayerData.job)
+    if name then return name end
+  end
+
+  if type(xPlayer.jobs) == 'table' then
+    name = extractJobName(xPlayer.jobs.primary or xPlayer.jobs.main or xPlayer.jobs.job)
+    if name then return name end
+    for _, entry in pairs(xPlayer.jobs) do
+      name = extractJobName(entry)
+      if name then return name end
+    end
+  end
+
+  if type(xPlayer.getJobName) == 'function' then
+    local ok, data = pcall(xPlayer.getJobName, xPlayer)
+    if ok then
+      name = extractJobName(data) or data
+      if name and name ~= '' then return name end
+    end
+  end
+
+  return nil
+end
+
 function Perms.canWrite(source)
   if not ESX then return true end -- fallback
   local xPlayer = ESX.GetPlayerFromId(source)
   if not xPlayer then return false end
-  local job = xPlayer.getJob and xPlayer.getJob() or {}
-  return job.name == Config.WriterJob
+
+  local jobName = resolveJobName(xPlayer)
+  return jobMatches(jobName)
 end
 
 function Perms.canReadDocument(source, doc)
+  doc = doc or {}
   if doc.revoked == 1 then return false end
-  -- If police read is allowed, allow police job
-  if Config.AllowPoliceRead and ESX then
-    local xPlayer = ESX.GetPlayerFromId(source)
-    local job = xPlayer and xPlayer.getJob() or {}
-    if job and job.name == 'police' then return true end
+  if not ESX then return true end
+
+  local xPlayer = ESX.GetPlayerFromId(source)
+  if not xPlayer then return true end
+
+  local jobName = resolveJobName(xPlayer)
+  if jobMatches(jobName) then return true end
+
+  if Config.AllowPoliceRead then
+    if normalizeJobName(jobName) == 'police' then
+      return true
+    end
   end
+
+  if doc then
+    local identifier = Utils and Utils.getIdentifier and Utils.getIdentifier(source)
+    if identifier then
+      if doc.author_identifier and identifierMatches(doc.author_identifier, identifier) then
+        return true
+      end
+
+      local printedBy = doc.printed_by
+      if type(printedBy) == 'table' then
+        printedBy = printedBy.identifier or printedBy.license or printedBy.id or printedBy.source
+      end
+
+      if printedBy and identifierMatches(printedBy, identifier) then
+        return true
+      end
+
+      local owner = doc.owner_identifier or doc.owner
+      if owner and identifierMatches(owner, identifier) then
+        return true
+      end
+    end
+  end
+
   -- By default documents are readable by anyone who physically has the item
   return true
 end

--- a/Outlaw_LawTablet/shared/utils.lua
+++ b/Outlaw_LawTablet/shared/utils.lua
@@ -15,6 +15,34 @@ function Utils.nowUtcIso()
   return os.date('!%Y-%m-%dT%H:%M:%SZ')
 end
 
+function Utils.toIso8601(value)
+  if value == nil then return nil end
+
+  if type(value) == 'number' then
+    return os.date('!%Y-%m-%dT%H:%M:%SZ', value)
+  end
+
+  if type(value) == 'string' then
+    local y, m, d, h, min, s = value:match('^(%d+)%-(%d+)%-(%d+) (%d+):(%d+):(%d+)$')
+    if y then
+      local stamp = os.time({
+        year = tonumber(y),
+        month = tonumber(m),
+        day = tonumber(d),
+        hour = tonumber(h),
+        min = tonumber(min),
+        sec = tonumber(s),
+        isdst = false
+      })
+      if stamp then
+        return os.date('!%Y-%m-%dT%H:%M:%SZ', stamp)
+      end
+    end
+  end
+
+  return value
+end
+
 -- Simple JSON helpers
 function Utils.jsonEncode(tbl)
   return json.encode(tbl or {})


### PR DESCRIPTION
## Summary
- store complete note snapshots in printed document metadata and persist them to the database so inventory items keep their content
- hydrate the viewer from stored metadata before falling back to database fetches, ensuring printed items open even if the source note is missing
- document the new metadata behaviour in the README for server owners

## Testing
- not run (luac unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9c50cc6508328a11fd08c8393eb66