### PR TITLE
Fix note list row interpolation

### DIFF
--- a/Outlaw_LawTablet/html/app.js
+++ b/Outlaw_LawTablet/html/app.js
@@ -44,10 +44,10 @@ function rowEl(item) {
   div.className = 'row';
   div.innerHTML = `
     <div>
-      <div class="title">\${item.title}</div>
-      <div class="type">\${item.type} • \${item.status}</div>
+      <div class="title">${item.title}</div>
+      <div class="type">${item.type} • ${item.status}</div>
     </div>
-    <div class="id">#\${item.id}</div>`;
+    <div class="id">#${item.id}</div>`;
   return div;
 }
 


### PR DESCRIPTION
## Summary
- render note list rows with actual metadata instead of literal placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac38dec508328be3c7bdc87cd0289